### PR TITLE
PHPdocumentor2, custom error messages and custom IDs for input elements.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+1.6.8
+	Input form macro now accepts an id variable, falling back to a default of element/getId if not defined.
+
+----------------
+1.6.7
+	Textarea form elements can be translated with i18n.
+
+----------------
 1.6.6
 	Textarea form elements can now make use of the placeholder attribute.
 

--- a/Macros/ztal/form.xhtml
+++ b/Macros/ztal/form.xhtml
@@ -210,7 +210,7 @@
 		ztal:data-attributes="element"
 		tal:attributes="type Ztal\Tales\Form.inputType:element;
 						   name name | Ztal\Tales\Generic.isTrue:simpleElementNames,element/getName | element/getFullyQualifiedName;
-						   id element/getId;
+						   id id | element/getId;
 						   class Ztal\Tales\Form.getAttrib:element,string:class;
 						   value value | nothing;
 						   maxlength Ztal\Tales\Form.getAttrib:element,string:maxlength;

--- a/Macros/ztal/form.xhtml
+++ b/Macros/ztal/form.xhtml
@@ -89,23 +89,25 @@
 			</ul>
 
 			<!-- loop through all the elements with errors -->
-			<tal:block tal:repeat="elementErrors form/getErrors">
-				<ul tal:condition="elementErrors">
-					<!--
-						For each element with errors, show the element
-						name and a ul list of errors
-					-->
-					<li tal:define="element Ztal\Tales\Form.getElement:form,repeat/elementErrors/key">
-						<tal:inline i18n:translate="element/getLabel" />
-						<ul>
-							<li
-								tal:repeat="error elementErrors"
-								i18n:domain="errorMessage_${repeat/elementErrors/key}"
-								i18n:translate="error"
-							/>
-						</ul>
-					</li>
-				</ul>
+			<tal:block tal:repeat="element form/getElements">
+				<tal:block tal:define="elementErrors Ztal\Tales\Form.getErrors:form,repeat/element/key;">
+					<ul tal:condition="exists:elementErrors">
+						<!--
+							For each element with errors, show the element
+							name and a ul list of errors
+						-->
+						<li>
+							<tal:inline i18n:translate="element/getLabel" />
+							<ul>
+								<li
+									tal:repeat="error elementErrors"
+									i18n:domain="errorMessage_${repeat/element/key}"
+									i18n:translate="error"
+								/>
+							</ul>
+						</li>
+					</ul>
+				</tal:block>
 			</tal:block>
 		</div>
 	</tal:block>

--- a/Tales/Form.php
+++ b/Tales/Form.php
@@ -137,11 +137,13 @@ final class Form implements \PHPTAL_Tales
 			$b = substr($src, 0, $break);
 			$rest = substr($src, $break + 1);
 		}
-		return '(count(' . phptal_tale($a, $nothrow) . '->getErrors('
-			. phptal_tale($b, $nothrow) . ')) > 0 ? '
-			. phptal_tale($a, $nothrow) . '->getErrors('
-			. phptal_tale($b, $nothrow) . ') : '
-			. phptal_tale($rest, $nothrow) . ')';
+		return '((count(' . phptal_tale($a, $nothrow) . '->getErrors(' . phptal_tale($b, $nothrow) . ')) > 0'
+			. ' || count(' . phptal_tale($a, $nothrow) . '->getElement(' . phptal_tale($b, $nothrow) . ')->getErrorMessages()) > 0)'
+			. ' ? array_merge('
+			. phptal_tale($a, $nothrow) . '->getErrors(' . phptal_tale($b, $nothrow) . '), '
+			. phptal_tale($a, $nothrow) . '->getElement(' . phptal_tale($b, $nothrow) . ')->getErrorMessages()'
+			. ')'
+			. ' : ' . phptal_tale($rest, $nothrow) . ')';
 	}
 
 

--- a/build.xml
+++ b/build.xml
@@ -110,16 +110,11 @@
 		
 	</target>
 
-	<target name="document" depends="php-documentor" />
-
-	<target name="php-documentor">
-		<exec command="docblox run --title '${phing.project.name}'
-							  --target ${project.basedir}/build/docs
-							  --directory ."
-			  dir="${project.basedir}/source" checkreturn="true" />
-		<exec command="docblox transform --source ${project.basedir}/build/docs/structure.xml
-										 --target ${project.basedir}/build/docs"
-			  dir="${project.basedir}/source" checkreturn="true" />
+	<target name="document">
+		<echo>command="phpdoc run --title '${phing.project.name}' --target ${buildDir}/docs --directory ."</echo>
+		<echo>dir="${sourceDir}"</echo>
+		<exec command="phpdoc run --title '${phing.project.name}'
+			--target ${buildDir}/docs --directory ." dir="${sourceDir}" />
 	</target>
 
 	<target name="analysis" depends="sonar:configure, sonar:run" />


### PR DESCRIPTION
Needed to specify the ID on radio button inputs so updated input form macro to accept an id variable, falling back to a default of element/getId if not defined.

A few other things hanging around on this dev branch - build updated to use phpdocumentor2 and elements can support custom error messages.